### PR TITLE
Add stricter Ruff linting

### DIFF
--- a/dissect/qnxfs/__init__.py
+++ b/dissect/qnxfs/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.qnxfs.c_qnx4 import c_qnx4
 from dissect.qnxfs.c_qnx6 import c_qnx6, c_qnx6_be, c_qnx6_le
 from dissect.qnxfs.exceptions import (

--- a/dissect/qnxfs/c_qnx4.py
+++ b/dissect/qnxfs/c_qnx4.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.cstruct import cstruct
 
 qnx4_def = """

--- a/dissect/qnxfs/c_qnx6.py
+++ b/dissect/qnxfs/c_qnx6.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.cstruct import cstruct
 
 qnx6_def = """

--- a/dissect/qnxfs/exceptions.py
+++ b/dissect/qnxfs/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Error(Exception):
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ select = [
   "SLOT",
   "SIM",
   "TID",
-  "TCH",
+  "TC",
   "PTH",
   "PLC",
   "TRY",
@@ -102,8 +102,25 @@ select = [
   "PERF",
   "FURB",
   "RUF",
+  "D"
 ]
-ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003"]
+ignore = [
+    "E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003", "PLC0415",
+    # Ignore some pydocstyle rules for now as they require a larger cleanup
+    "D1",
+    "D205",
+    "D301",
+    "D417",
+    # Seems bugged: https://github.com/astral-sh/ruff/issues/16824
+    "D402",
+]
+future-annotations = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/_docs/**" = ["INP001"]
@@ -112,6 +129,7 @@ ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM1
 [tool.ruff.lint.isort]
 known-first-party = ["dissect.qnxfs"]
 known-third-party = ["dissect"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.setuptools.packages.find]
 include = ["dissect.*"]

--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 extensions = [
     "autoapi.extension",
     "sphinx.ext.autodoc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 if typing.TYPE_CHECKING:
     from collections.abc import Iterator
 
+
 def absolute_path(filename: str) -> Path:
     return Path(__file__).parent / filename
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import gzip
-from collections.abc import Iterator
+import typing
 from pathlib import Path
 from typing import IO, BinaryIO
 
 import pytest
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
 
 def absolute_path(filename: str) -> Path:
     return Path(__file__).parent / filename

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from dissect.qnxfs import exceptions


### PR DESCRIPTION
Add stricter rules (doctstyle) + Add annotations import to ruff isort required imports.

Code change are only related to addition of from future import annotations Regarding few change, I suggest to not add this commit to git blame ignore file.

* fixes #5 